### PR TITLE
Adds imap support to php for owncloud to auth against

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --update \
   php5-gd \
   php5-gmp \
   php5-iconv \
+  php5-imap \
   php5-intl \
   php5-json \
   php5-ldap \


### PR DESCRIPTION
This is a one-liner that works (I've already pushed to imartyn/nextcloud on docker if you want to see) to enable imap support in php for owncloud to use in it's already installed but not enabled module.