### PR TITLE
Update apcu.ini | removed extension=apcu.so

### DIFF
--- a/root/usr/local/etc/php/conf.d/apcu.ini
+++ b/root/usr/local/etc/php/conf.d/apcu.ini
@@ -1,4 +1,3 @@
-extension=apcu.so
 apc.enabled=1
 apc.shm_size=128M
 apc.ttl=7200


### PR DESCRIPTION
Module already loaded by /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini