### PR TITLE
Rise fastcgi_read_timeout

### DIFF
--- a/root/etc/nginx/nginx.conf
+++ b/root/etc/nginx/nginx.conf
@@ -56,6 +56,7 @@ http {
     client_max_body_size 10G;
     client_body_buffer_size 400M;
     fastcgi_buffers 64 4K;
+    fastcgi_read_timeout 600;
 
     rewrite ^/caldav(.*)$ /remote.php/caldav$1 redirect;
     rewrite ^/carddav(.*)$ /remote.php/carddav$1 redirect;

--- a/root/usr/local/etc/php/conf.d/docker-nextcloud-exec-time.ini
+++ b/root/usr/local/etc/php/conf.d/docker-nextcloud-exec-time.ini
@@ -1,0 +1,1 @@
+max_execution_time = 600


### PR DESCRIPTION
Now uploading bigger files shouldn't timeout