### PR TITLE
pip3 has its own package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN set -ex \
   postgresql-dev \
   postgresql-libs \
   python3 \
+  py3-pip \
   samba-client \
   sudo \
   supervisor \


### PR DESCRIPTION
resolve issue during build

`+ pip3 install supervisor-stdout
/bin/sh: pip3: not found
`